### PR TITLE
QA: mypy, reformatting, and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,12 @@ jobs:
       - name: test
         run: make test INSTALL_EXTRA=test
 
-#   lint:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v3
-#       - uses: actions/setup-python@v4
-#         with:
-#           python-version: "3.10"
-#       - name: lint
-#         run: make lint INSTALL_EXTRA=lint
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: lint
+        run: make lint INSTALL_EXTRA=lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+on:
+  release:
+    types:
+      - published
+
+name: release
+
+jobs:
+  pypi:
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      # Used for OIDC publishing.
+      # Used to sign the release's artifacts with sigstore-python.
+      id-token: write
+
+      # Used to attach signing artifacts to the published release.
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+
+    - name: deps
+      run: python -m pip install -U setuptools build wheel
+
+    - name: build
+      run: python -m build
+
+    - name: publish
+      uses: pypa/gh-action-pypi-publish@v1.8.6
+
+    - name: sign
+      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      with:
+        inputs: ./dist/*.tar.gz ./dist/*.whl
+        release-signing-artifacts: true
+        bundle-only: true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # stdlib-list
 
-This package includes lists of all of the standard libraries for Python 2.6,
-2.7, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, and 3.9 along with the code for
-scraping the official Python docs to get said lists.
+This package includes lists of all of the standard libraries for Python 2.6
+through 3.11.
 
 **IMPORTANT**: If you're on Python 3.10 or newer, you **probably don't need this library**.
 See [`sys.stdlib_module_names`](https://docs.python.org/3/library/sys.html#sys.stdlib_module_names)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,10 +30,9 @@ from stdlib_list import __version__
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
-    "sphinx_rtd_theme",
 ]
 
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -48,8 +47,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = "Python Standard Library List"
-copyright = "2015, Jack Maney"
+project = "stdlib-list"
+copyright = "2015, stdlib-list authors"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,21 +1,15 @@
-.. Python Standard Library List documentation master file, created by
-   sphinx-quickstart on Tue Mar 10 02:16:08 2015.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+stdlib-list
+===========
 
-Python Standard Library List
-========================================================
+This package includes lists of all of the standard libraries for Python 2.6
+through 3.11.
 
-This package includes lists of all of the standard libraries for Python 2.6, 2.7, 3.2, 3.3, and 3.4, along with the code for scraping the official Python docs to get said lists.
+.. note::
 
-Listing the modules in the standard library? Wait, why on Earth would you care about that?!
-===========================================================================================
-
-Because knowing whether or not a module is part of the standard library will come in handy in `a project of mine <https://github.com/jackmaney/pypt>`_. `And I'm not the only one <http://stackoverflow.com/questions/6463918/how-can-i-get-a-list-of-all-the-python-standard-library-modules>`_ who would find this useful. Or, the TL;DR answer is that it's handy in situations when you're analyzing Python code and would like to find module dependencies.
-
-After googling for a way to generate a list of Python standard libraries (and looking through the answers to the previously-linked Stack Overflow question), I decided that I didn't like the existing solutions. So, I started by writing a scraper for the TOC of the Python Module Index for each of the versions of Python above.
-
-However, web scraping can be a fragile affair. Thanks to `a suggestion <https://github.com/jackmaney/python-stdlib-list/issues/1#issuecomment-86517208>`_ by `@ncoghlan <https://github.com/ncoghlan>`_, and some further help from `@birkenfeld <https://github.com/birkenfeld>`_ and `@epc <https://github.com/epc>`_, the population of the lists is now done by grabbing and parsing the Sphinx object inventory for the official Python docs of each relevant version.
+   If you're on Python 3.10 or newer, you **probably don't need this library**.
+   See `sys.stdlib_module_names <https://docs.python.org/3/library/sys.html#sys.stdlib_module_names>`_
+   and `sys.builtin_module_names <https://docs.python.org/3/library/sys.html#sys.builtin_module_names>`_
+   for similar functionality.
 
 Contents
 ========

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,22 @@ dev = ["build", "stdlib-list[test,lint,doc]"]
 # CI only: used for list generation for Python versions < 3.10.
 support = ["sphobjinv"]
 
+[tool.mypy]
+allow_redefinition = true
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+ignore_missing_imports = true
+no_implicit_optional = true
+show_error_codes = true
+sqlite_cache = true
+strict_equality = true
+warn_no_return = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_configs = true
+warn_unused_ignores = true
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,4 @@ line-length = 100
 [tool.ruff]
 select = ["E", "F", "I", "W", "UP"]
 target-version = "py37"
+line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Source = "https://github.com/pypi/stdlib-list"
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov", "coverage[toml]"]
 lint = ["black", "mypy", "ruff"]
-doc = ["sphinx", "sphinx_rtd_theme"]
+doc = ["sphinx", "furo"]
 dev = ["build", "stdlib-list[test,lint,doc]"]
 # CI only: used for list generation for Python versions < 3.10.
 support = ["sphobjinv"]

--- a/stdlib_list/__init__.py
+++ b/stdlib_list/__init__.py
@@ -2,11 +2,11 @@ __version__ = "0.8.1rc0"
 
 # Import all the things that used to be in here for backwards-compatibility reasons
 from .base import (
-    stdlib_list,
-    in_stdlib,
     get_canonical_version,
-    short_versions,
+    in_stdlib,
     long_versions,
+    short_versions,
+    stdlib_list,
 )
 
 __all__ = [

--- a/stdlib_list/base.py
+++ b/stdlib_list/base.py
@@ -1,9 +1,6 @@
-from __future__ import print_function, absolute_import
-
 import os
 import pkgutil
 import sys
-
 from functools import lru_cache
 
 long_versions = [
@@ -24,16 +21,16 @@ long_versions = [
 short_versions = [".".join(x.split(".")[:2]) for x in long_versions]
 
 
-def get_canonical_version(version):
+def get_canonical_version(version: str) -> str:
     if version in long_versions:
         version = ".".join(version.split(".")[:2])
     elif version not in short_versions:
-        raise ValueError("No such version: {}".format(version))
+        raise ValueError(f"No such version: {version}")
 
     return version
 
 
-def stdlib_list(version=None):
+def stdlib_list(version: str | None = None) -> list[str]:
     """
     Given a ``version``, return a ``list`` of names of the Python Standard
     Libraries for that version.
@@ -53,9 +50,9 @@ def stdlib_list(version=None):
         else ".".join(str(x) for x in sys.version_info[:2])
     )
 
-    module_list_file = os.path.join("lists", "{}.txt".format(version))
+    module_list_file = os.path.join("lists", f"{version}.txt")
 
-    data = pkgutil.get_data("stdlib_list", module_list_file).decode()
+    data = pkgutil.get_data("stdlib_list", module_list_file).decode()  # type: ignore[union-attr]
 
     result = [y for y in [x.strip() for x in data.splitlines()] if y]
 
@@ -63,13 +60,13 @@ def stdlib_list(version=None):
 
 
 @lru_cache(maxsize=16)
-def _stdlib_list_with_cache(version=None):
+def _stdlib_list_with_cache(version: str | None = None) -> list[str]:
     """Internal cached version of `stdlib_list`"""
     return stdlib_list(version=version)
 
 
 @lru_cache(maxsize=256)
-def in_stdlib(module_name, version=None):
+def in_stdlib(module_name: str, version: str | None = None) -> bool:
     """
     Return a ``bool`` indicating if module ``module_name`` is in the list of stdlib
     symbols for python version ``version``. If ``version`` is ``None`` (default), the

--- a/stdlib_list/base.py
+++ b/stdlib_list/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pkgutil
 import sys

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,5 @@
 import pkgutil
+
 import pytest
 
 import stdlib_list


### PR DESCRIPTION
This runs the configured formatting and linting tools over the codebase and checks the results in.

It also adds a reasonably strict set of `mypy` settings, type hints, and a `py.typed` marker for downstream consumers.
