### PR TITLE
drop 3.7 and 3.8, prep for 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,11 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.7"
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/listgen.yml
+++ b/.github/workflows/listgen.yml
@@ -108,6 +108,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 
     runs-on: ubuntu-latest
 

--- a/Makefile
+++ b/Makefile
@@ -56,15 +56,15 @@ $(VENV)/pyvenv.cfg: pyproject.toml
 .PHONY: lint
 lint: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
-		black --check $(ALL_PY_SRCS) && \
+		ruff format --check $(ALL_PY_SRCS) && \
 		ruff check $(ALL_PY_SRCS) && \
 		mypy $(PY_MODULE)
 
 .PHONY: reformat
 reformat:
 	. $(VENV_BIN)/activate && \
-		ruff --fix $(ALL_PY_SRCS) && \
-		black $(ALL_PY_SRCS)
+		ruff check --fix $(ALL_PY_SRCS) && \
+		ruff format $(ALL_PY_SRCS)
 
 .PHONY: test tests
 test tests: $(VENV)/pyvenv.cfg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = []
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 
 [project.urls]
 Homepage = "https://pypi.org/project/stdlib-list/"
@@ -34,7 +34,7 @@ Documentation = "https://pypi.github.io/stdlib-list/"
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov", "coverage[toml]"]
-lint = ["black", "mypy", "ruff"]
+lint = ["mypy", "ruff"]
 doc = ["sphinx", "furo"]
 dev = ["build", "stdlib-list[test,lint,doc]"]
 # CI only: used for list generation for Python versions < 3.10.
@@ -57,10 +57,6 @@ warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
 
-[tool.black]
-line-length = 100
-
 [tool.ruff]
 lint.select = ["E", "F", "I", "W", "UP"]
-target-version = "py37"
 line-length = 100


### PR DESCRIPTION
This removes 3.7 and 3.8 (both EOL) and adds 3.13 to the test matrix. It also adds it to the listgen, meaning that once merged the CI will generate an appropriate PR for the 3.13 stdlib list.