### PR TITLE
Add 3.13 to the version list so `stdlib_list("3.13")` works.

### DIFF
--- a/stdlib_list/base.py
+++ b/stdlib_list/base.py
@@ -19,6 +19,7 @@ long_versions = [
     "3.10",
     "3.11",
     "3.12",
+    "3.13",
 ]
 
 short_versions = [".".join(x.split(".")[:2]) for x in long_versions]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,4 @@
-import pkgutil
+from importlib import resources
 
 import pytest
 
@@ -22,9 +22,17 @@ def test_get_canonical_version_raises(version):
 @pytest.mark.parametrize("version", [*stdlib_list.short_versions, *stdlib_list.long_versions])
 def test_self_consistent(version):
     list_path = f"lists/{stdlib_list.get_canonical_version(version)}.txt"
-    modules = pkgutil.get_data("stdlib_list", list_path).decode().splitlines()
+    modules = resources.files("stdlib_list").joinpath(list_path).read_text().splitlines()
 
     for mod_name in modules:
         assert stdlib_list.in_stdlib(mod_name, version)
 
     assert modules == stdlib_list.stdlib_list(version)
+
+
+@pytest.mark.parametrize(
+    "version_file", [f.name for f in resources.files("stdlib_list").joinpath("lists").iterdir()]
+)
+def test_self_consistent_reverse(version_file):
+    version = version_file.removesuffix(".txt")
+    assert stdlib_list.stdlib_list(version)


### PR DESCRIPTION
`stdlib_list("3.13")` is useful if you want to get the Python 3.13 stdlib list but are still running an older Python version.

Also added a test to ensure self consistent from the other direction: `lists/*.txt` files have a corresponding entry in the short/long_versions list.