### PR TITLE
Use ``submodule_search_locations`` correctly

### DIFF
--- a/support/walk-modules.py
+++ b/support/walk-modules.py
@@ -78,9 +78,12 @@ def walk(mod_name: str, io: Writer) -> None:
     try:
         locations = mod.__spec__.submodule_search_locations
     except AttributeError:
-        walk_naive(mod_name, mod, io)
-    else:
+        locations = None
+
+    if locations is not None:
         walk_pkgutil(mod_name, locations, io)
+    else:
+        walk_naive(mod_name, mod, io)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
cc @miketheman (my flight's been delayed!)

`submodule_search_locations` can be `None`, which is interpreted by `pkgutil.walk_packages()` as 'all top-level modules on sys.path'. This is not the desired behaviour.

Instead of trying to be clever with try/except, we now use an explicit `is not None` check.

A 