### PR TITLE
docs: Correct covered Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Downloads](https://static.pepy.tech/badge/stdlib-list)](https://pepy.tech/project/stdlib-list)
 [![CI](https://github.com/pypi/stdlib-list/actions/workflows/ci.yml/badge.svg)](https://github.com/pypi/stdlib-list/actions/workflows/ci.yml)
 
-This package includes lists of all of the standard libraries for Python 2.6
-through 3.14.
+This package includes lists of all of the standard libraries for Python 2.6-2.7,
+3.2-3.14.
 
 **IMPORTANT**: If you're on Python 3.10 or newer, you **probably don't need this library**.
 See [`sys.stdlib_module_names`](https://docs.python.org/3/library/sys.html#sys.stdlib_module_names)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,8 @@
 stdlib-list
 ===========
 
-This package includes lists of all of the standard libraries for Python 2.6
-through 3.14.
+This package includes lists of all of the standard libraries for Python 2.6-2.7,
+3.2-3.14.
 
 .. note::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = ["tests/"]
 [project]
 name = "stdlib-list"
 dynamic = ["version"]
-description = "A list of Python Standard Libraries (2.7 through 3.14)."
+description = "A list of Python Standard Libraries (2.6-2.7, 3.2-3.14)."
 readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "Jack Maney", email = "jackmaney@gmail.com" }]


### PR DESCRIPTION
As per the Github repo About summary Python 3.0 & 3.1 are not covered. I chose a different range notation to the About summary - to maintain grep-ability.