### PR TITLE
Restrict OIDC token to publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,18 +8,11 @@ name: release
 permissions: {}
 
 jobs:
-  pypi:
-    name: upload release to PyPI
+  build:
+    name: build release distributions
     runs-on: ubuntu-latest
-    environment: release
     permissions:
-      # Used for OIDC publishing.
-      # Used to sign the release's artifacts with sigstore-python.
-      id-token: write
-
-      # Used to attach signing artifacts to the published release.
-      contents: write
-
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -34,6 +27,33 @@ jobs:
 
       - name: build
         run: python -m build
+
+      - name: upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: distributions
+          path: dist/
+          if-no-files-found: error
+
+  pypi:
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    environment: release
+    permissions:
+      # Used for OIDC publishing.
+      # Used to sign the release's artifacts with sigstore-python.
+      id-token: write
+
+      # Used to attach signing artifacts to the published release.
+      contents: write
+
+    steps:
+      - name: download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: distributions
+          path: dist/
 
       - name: publish
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,6 @@ jobs:
       # Used to sign the release's artifacts with sigstore-python.
       id-token: write
 
-      # Used to attach signing artifacts to the published release.
-      contents: write
-
     steps:
       - name: download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -57,5 +54,3 @@ jobs:
 
       - name: publish
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          attestations: true


### PR DESCRIPTION
The GH OIDC token used for Trusted Publishing should not be available to non-publishing steps. This PR removes it from the steps that install the dependencies and build the project, so that it's only available during PyPI publishing.

Also removes `attestations: true` (since `true` is already the default) and `contents: write` (since it's not being used)

cc @miketheman